### PR TITLE
Support openstack antelope (ubuntu 22.04) (cinder 9.3.0)

### DIFF
--- a/infortrend/raidcmd_cli/common_cli.py
+++ b/infortrend/raidcmd_cli/common_cli.py
@@ -30,7 +30,7 @@ from cinder import exception
 from cinder.i18n import _
 from cinder.volume.drivers.infortrend.raidcmd_cli import cli_factory as cli
 from cinder.volume.drivers.san import san
-from cinder.volume import utils
+from cinder.volume import volume_utils
 from cinder.volume import volume_types
 from cinder.zonemanager import utils as fczm_utils
 
@@ -2615,7 +2615,7 @@ class InfortrendCommon(object):
             }
             manageable_volumes.append(volume)
 
-        return utils.paginate_entries_list(manageable_volumes, marker, limit,
+        return volume_utils.paginate_entries_list(manageable_volumes, marker, limit,
                                            offset, sort_keys, sort_dirs)
 
     def manage_existing_snapshot(self, snapshot, existing_ref):
@@ -2702,7 +2702,7 @@ class InfortrendCommon(object):
 
             manageable_snapshots.append(return_si)
 
-        return utils.paginate_entries_list(manageable_snapshots, marker, limit,
+        return volume_utils.paginate_entries_list(manageable_snapshots, marker, limit,
                                            offset, sort_keys, sort_dirs)
 
     def unmanage_snapshot(self, snapshot):


### PR DESCRIPTION
from cinder.volume import utils -> volume_utils